### PR TITLE
Fix failing test

### DIFF
--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -45,14 +45,19 @@ module NETBuildpack::Util
 	  	  	cmd_file.write(cmd)
 	  	  	cmd_file.close
 	  	  	cmd = cmd_file.path
-	  	  	File.chmod(0777, cmd)
+	  	  	File.chmod(0744, cmd)
 	  	  end
 			  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
-		      stdout_and_err.each do |line| 
-		      	output += line
-		      	print line unless options[:silent]
+			  	begin
+			      stdout_and_err.each do |line| 
+			      	output += line
+			      	print line unless options[:silent]
+			      end
+			    rescue Errno::EIO
+			    	#ignore - see http://stackoverflow.com/questions/10238298/ruby-on-linux-pty-goes-away-without-eof-raises-errnoeio
+		      ensure
+		      	Process.wait(pid)
 		      end
-		      Process.wait(pid)
 			  end
 			  logger.log output
 			  exit_value = $?.exitstatus

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -45,7 +45,7 @@ module NETBuildpack::Util
 	  	  	cmd_file.write(cmd)
 	  	  	cmd_file.close
 	  	  	cmd = cmd_file.path
-	  	  	File.chmod(0744, cmd)
+	  	  	File.chmod(0777, cmd)
 	  	  end
 			  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
 		      stdout_and_err.each do |line| 

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -44,7 +44,9 @@ module NETBuildpack::Util
 			      	print line unless options[:silent]
 			      end
 			      Process.wait(pid)
-			    rescue Errno::EIO
+			    rescue Exception => exception_msg  
+			    	logger.log "Exception raised with #{exception_msg}.\nReturning exit code 127"
+			    	return 127
 			    end
 			    logger.log output
 			  end

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -37,19 +37,24 @@ module NETBuildpack::Util
 	  	  require 'pty'
 	  	  output = "#{cmd} ==>\n\n"
 	  	  puts cmd unless options[:silent]
-			  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
-			    begin
-			      stdout_and_err.each do |line| 
-			      	output += line
-			      	print line unless options[:silent]
-			      end
-			      Process.wait(pid)
-			    rescue Exception => exception_msg  
-			    	logger.log "Exception raised with #{exception_msg}.\nReturning exit code 127"
-			    	return 127
-			    end
-			    logger.log output
-			  end
+	  	  begin
+				  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
+				    begin
+				      stdout_and_err.each do |line| 
+				      	output += line
+				      	print line unless options[:silent]
+				      end
+				      Process.wait(pid)
+				    rescue => exception_msg  
+				    	logger.log "#{exception_msg} - exit 127"
+				    	return 127
+				    end
+				    logger.log output
+				  end
+		    rescue Errno::ENOENT
+					logger.log "Errno::ENOENT: No such file or directory - exit 127"
+					return 127
+			  end  	
 			  exit_value = $?.exitstatus
 			end
 			return exit_value

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require 'net_buildpack/util'
+require 'tempfile'
 
 
 module NETBuildpack::Util
@@ -37,24 +38,23 @@ module NETBuildpack::Util
 	  	  require 'pty'
 	  	  output = "#{cmd} ==>\n\n"
 	  	  puts cmd unless options[:silent]
-	  	  begin
-				  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
-				    begin
-				      stdout_and_err.each do |line| 
-				      	output += line
-				      	print line unless options[:silent]
-				      end
-				      Process.wait(pid)
-				    rescue => exception_msg  
-				    	logger.log "#{exception_msg} - exit 127"
-				    	return 127
-				    end
-				    logger.log output
-				  end
-		    rescue Errno::ENOENT
-					logger.log "Errno::ENOENT: No such file or directory - exit 127"
-					return 127
-			  end  	
+	  	  #Wrap bash commands in a script so that PTY.spawn will run them.
+	  	  unless File.exists?(cmd)
+	  	  	cmd_file = Tempfile.new('net_buildpack_run_command.sh')
+	  	  	cmd_file.write("#!/usr/bin/env bash\n")
+	  	  	cmd_file.write(cmd)
+	  	  	cmd_file.close
+	  	  	cmd = cmd_file.path
+	  	  	File.chmod(0744, cmd)
+	  	  end
+			  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
+		      stdout_and_err.each do |line| 
+		      	output += line
+		      	print line unless options[:silent]
+		      end
+		      Process.wait(pid)
+			  end
+			  logger.log output
 			  exit_value = $?.exitstatus
 			end
 			return exit_value

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -19,7 +19,7 @@ require 'net_buildpack/util/run_command'
 
 module NETBuildpack::Util
 
-  describe RunCommand do
+  describe RunCommand, :focus => true do
 
     let(:logger) { double('logger', log: nil) }
 
@@ -29,7 +29,7 @@ module NETBuildpack::Util
     end
 
     it 'returns an error exit code' do
-      exit_value = NETBuildpack::Util::RunCommand.exec("ls /this/doesnt/exist/foo/bar.baz", logger, { :silent => true })
+      exit_value = NETBuildpack::Util::RunCommand.exec("echo 'Simulating exitcode 1' && exit 1", logger, { :silent => true })
       expect(exit_value).to eq(1)
     end
 

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -34,8 +34,8 @@ module NETBuildpack::Util
     end
 
     it 'returns an error exit code for a short running erroring command' do
-      exit_value = NETBuildpack::Util::RunCommand.exec("exit 127", logger, { :silent => true })
-      expect(exit_value).to eq(127)
+      exit_value = NETBuildpack::Util::RunCommand.exec("exit 2", logger, { :silent => true })
+      expect(exit_value).to eq(2)
     end
 
     it 'streams output from long running processes' do

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -19,7 +19,7 @@ require 'net_buildpack/util/run_command'
 
 module NETBuildpack::Util
 
-  describe RunCommand, :focus => true do
+  describe RunCommand do
 
     let(:logger) { double('logger', log: nil) }
 

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -28,9 +28,14 @@ module NETBuildpack::Util
       expect(exit_value).to eq(0)
     end
 
-    it 'returns an error exit code' do
-      exit_value = NETBuildpack::Util::RunCommand.exec("echo 'Simulating exitcode 1' && exit 1", logger, { :silent => true })
+    it 'returns an error exit code for a long running erroring command' do
+      exit_value = NETBuildpack::Util::RunCommand.exec("sleep 0.2 && exit 1", logger, { :silent => true })
       expect(exit_value).to eq(1)
+    end
+
+    it 'returns an error exit code for a short running erroring command' do
+      exit_value = NETBuildpack::Util::RunCommand.exec("exit 127", logger, { :silent => true })
+      expect(exit_value).to eq(127)
     end
 
     it 'streams output from long running processes' do


### PR DESCRIPTION
Travis CI builds are failing with:

```
Failures:
  1) NETBuildpack::Util::RunCommand returns an error exit code
     Failure/Error: expect(exit_value).to eq(1)

       expected: 1
            got: 0

       (compared using ==)
     # ./spec/net_buildpack/util/run_command_spec.rb:33:in `block (2 levels) in <module:Util>'
```

This seems to be because `ls /this/doesnt/exist/foo/bar.baz` doesn't error with an exit code of 1 as expected.
