### PR TITLE
Update to Mono 3.2.3_full

### DIFF
--- a/config/mono.yml
+++ b/config/mono.yml
@@ -16,4 +16,4 @@
 # Configuration for Mono repositories
 ---
 repository_root: "https://ci-labs-buildpack-downloads.s3.amazonaws.com/mono/lucid/x86_64"
-version: 3.2.0_full
+version: 3.2.3_full

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -154,7 +154,7 @@ module NETBuildpack::Runtime
     #
     # @return [String]
     def runtime_command
-      "#{runtime_time_absolute_path(setup_mono)} && #{runtime_time_absolute_path(mono_bin)}"
+      "#{runtime_time_absolute_path(setup_mono)} && #{runtime_time_absolute_path(mono_bin)} --server"
     end
 
   end

--- a/spec/bin/release_spec.rb
+++ b/spec/bin/release_spec.rb
@@ -41,7 +41,7 @@ describe 'release script', :integration do
       with_memory_limit('1G') do
         Open3.popen3("bin/release #{root}") do |stdin, stdout, stderr, wait_thr|
            exit_value = wait_thr.value
-           expect(stdout.read).to include('web: /app/vendor/mono/bin/setup_mono && /app/vendor/mono/bin/mono z-Start.exe')
+           expect(stdout.read).to include('web: /app/vendor/mono/bin/setup_mono && /app/vendor/mono/bin/mono --server z-Start.exe')
         end
       end
 

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -151,6 +151,24 @@ module NETBuildpack::Runtime
       end
     end
 
+    it 'runs mono with the --server flag (see http://www.mono-project.com/Release_Notes_Mono_3.2#New_in_Mono_3.2.3)' do
+      Dir.mktmpdir do |root|
+        NETBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(DETAILS)
+
+        run_command = ""
+        Mono.new(
+            :app_dir => root,
+            :runtime_home => '',
+            :runtime_command => run_command,
+            :config_vars => {},
+            :diagnostics => {:directory => 'fake-diagnostics-dir'},
+            :configuration => {}
+        ).release
+
+        expect(run_command).to include("mono --server")
+      end
+    end
+
     it 'adds correct env vars to config_vars ' do
       Dir.mktmpdir do |root|
         NETBuildpack::Repository::ConfiguredItem.stub(:find_item).and_return(DETAILS)


### PR DESCRIPTION
As requested in #19, the buildpack should be updated to use the latest Mono 3.2.3 runtime.

This depends on related update to the [cloudfoundry-community/builder-mono](https://github.com/cloudfoundry-community/builder-mono/commit/a88e82f294d8cddc25c17a18d53816bc6787663e) project.

This gives a host of improvements, mainly bugfixes and and JIT/GC optimizations. See http://www.mono-project.com/Release_Notes_Mono_3.2#New_in_Mono_3.2.3 for full details.

Of particular interest is the new `--server` flag which will become the default way of running mono used by the buildpack.

> Run mono with --server to tell the runtime to target performance. With this release, this means an aggressive threadpool scheduler that creates additional threads faster.
