### PR TITLE
Add Procfile container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc
 pkg
 buildpack.log
 spec/fixtures/mem_usage_tests/
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,6 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise64-ruby-1.9.3-p194"
+  config.vm.box_url = "https://dl.dropbox.com/u/14292474/vagrantboxes/precise64-ruby-1.9.3-p194.box"
+end
+
+ 

--- a/config/components.yml
+++ b/config/components.yml
@@ -20,6 +20,7 @@ runtimes:
   - "NETBuildpack::Runtime::CLR"
 containers:
   - "NETBuildpack::Container::Console"
+  - "NETBuildpack::Container::Procfile"
 # frameworks:
 #   - "JavaBuildpack::Framework::JavaOpts"
 #   - "JavaBuildpack::Framework::PlayAutoReconfiguration"

--- a/docs/container-procfile.md
+++ b/docs/container-procfile.md
@@ -1,0 +1,26 @@
+# NET Procfile Container
+The NET Procfile Container runs multiple processes as defined in a `Procfile` using [forego (Foreman in Go)](https://github.com/ddollar/forego).
+
+This is useful when your app needs to run more than a single process, eg you need a `web:` process and a `worker:` process 
+
+<table>
+  <tr>
+    <td><strong>Detection Criteria</strong></td><td><tt>Procfile</tt> in app root folder</td>
+  </tr>
+  <tr>
+    <td><strong>Tags</strong></td><td><tt>net-procfile</tt></td>
+  </tr>
+</table>
+
+The Procfile container generates a start command similar to:
+
+```
+/app/vendor/forego start -p $PORT
+```
+
+An example `Procfile` would be (see [spec/fixtures/procfile](https://github.com/cloudfoundry-community/.net-buildpack/tree/master/spec/fixtures/procfile]) for a full example app):
+
+```
+web: mono --server bin/myapp-web.exe -port $PORT
+worker: mono bin/myapp-worker.exe
+```

--- a/lib/net_buildpack/base_component.rb
+++ b/lib/net_buildpack/base_component.rb
@@ -1,0 +1,109 @@
+# Encoding: utf-8
+# Cloud Foundry NET Buildpack
+# Copyright 2013 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net_buildpack'
+require 'net_buildpack/util/run_command'
+require 'net_buildpack/util/application_cache'
+require 'net_buildpack/util/logger'
+
+module NETBuildpack
+
+  # A convenience base class for all components in the buildpack.  This base class ensures that the contents of the
+  # +context+ are assigned to instance variables matching their keys.  It also ensures that all contract methods are
+  # implemented.
+  class BaseComponent
+
+    # Creates an instance.  The contents of +context+ are assigned to instance variables matching their keys.
+    # +component_name+ and +context+ are exposed via +@component_name+ and +@context+ respectively for any component
+    # that wishes to use them.
+    #
+    # @param [Hash] context A shared context provided to all components
+    def initialize(component_name, context)
+      @component_name = component_name
+      @context = context
+      @context.each { |key, value| instance_variable_set("@#{key}", value) }
+      @logger ||= NETBuildpack::Util::NullLogger.new
+    end
+
+    # If the component should be used when staging an application
+    #
+    # @return [Array<String>, String, nil] If the component should be used when staging the application, a +String+ or
+    #                                      an +Array<String>+ that uniquely identifies the component (e.g.
+    #                                      +mono-3.2.3+).  Otherwise, +nil+.
+    def detect
+      fail "Method 'detect' must be defined"
+    end
+
+    # Modifies the application's file system.  The component is expected to transform the application's file system in
+    # whatever way is necessary (e.g. downloading files or creating symbolic links) to support the function of the
+    # component.  Status output written to +STDOUT+ is expected as part of this invocation.
+    #
+    # @return [void]
+    def compile
+      fail "Method 'compile' must be defined"
+    end
+
+    # Modifies the application's runtime configuration. The component is expected to transform members of the +context+
+    # (e.g. +@java_home+, +@java_opts+, etc.) in whatever way is necessary to support the function of the component.
+    #
+    # Container components are also expected to create the command required to run the application.  These components
+    # are expected to read the +context+ values and take them into account when creating the command.
+    #
+    # @return [void, String] components other than containers are not expected to return any value.  Container
+    #                        compoonents are expected to return the command required to run the application.
+    def release
+      fail "Method 'release' must be defined"
+    end
+
+    protected
+
+    # Times an operation
+    #
+    # @return [void]
+    def time_operation(&block)
+      start_time = Time.now
+      yield 
+      puts "(#{(Time.now - start_time).duration})"
+    end
+
+    # Downloads an item with the given name and version from the given URI, then yields the resultant file to the given
+    # block.
+    #
+    # @param [JavaBuildpack::Util::TokenizedVersion] version
+    # @param [String] uri
+    # @param [String] description an optional description for the download.  Defaults to +@component_name+.
+    # @return [void]
+    def download(version, uri, description = @component_name, &block)
+      download_start_time = Time.now
+      print "-----> Downloading #{description} #{version} from #{uri} "
+
+      NETBuildpack::Util::ApplicationCache.new.get(uri) do |file| # TODO: Use global cache #50175265
+        puts "(#{(Time.now - download_start_time).duration})"
+        yield file
+      end
+    end
+
+    # Run external shell commands, both streaming and logging output
+    #
+    # @param [String] cmd the shell script to run
+    # @param [Hash] options { :silent => true/false }
+    def sh(cmd, options)
+      NETBuildpack::Util::RunCommand.exec(cmd, @logger, options)
+    end
+
+  end
+
+end

--- a/lib/net_buildpack/base_component.rb
+++ b/lib/net_buildpack/base_component.rb
@@ -100,7 +100,7 @@ module NETBuildpack
     #
     # @param [String] cmd the shell script to run
     # @param [Hash] options { :silent => true/false }
-    def sh(cmd, options)
+    def sh(cmd, options = {})
       NETBuildpack::Util::RunCommand.exec(cmd, @logger, options)
     end
 
@@ -116,6 +116,13 @@ module NETBuildpack
       )
     end
 
+    def stage_time_absolute_path(path)
+      File.join @app_dir, path
+    end
+
+    def runtime_time_absolute_path(path)
+      File.join "/app", path
+    end
 
   end
 

--- a/lib/net_buildpack/base_component.rb
+++ b/lib/net_buildpack/base_component.rb
@@ -76,7 +76,7 @@ module NETBuildpack
     def time_operation(&block)
       start_time = Time.now
       yield 
-      puts "(#{(Time.now - start_time).duration})"
+      puts " (#{(Time.now - start_time).duration})"
     end
 
     # Downloads an item with the given name and version from the given URI, then yields the resultant file to the given

--- a/lib/net_buildpack/base_component.rb
+++ b/lib/net_buildpack/base_component.rb
@@ -104,6 +104,19 @@ module NETBuildpack
       NETBuildpack::Util::RunCommand.exec(cmd, @logger, options)
     end
 
+    # Replace strings in a file.  Modified the original file
+    #
+    # @param [String] filepath
+    # @param [String] old_value 
+    # @param [String] new_value 
+    def replace_in_file(filepath, old_value, new_value)
+      IO.write(filepath, File.open(filepath) do |f|
+                            f.read.gsub(/#{old_value}/, new_value)
+                          end 
+      )
+    end
+
+
   end
 
 end

--- a/lib/net_buildpack/base_component.rb
+++ b/lib/net_buildpack/base_component.rb
@@ -73,8 +73,9 @@ module NETBuildpack
     # Times an operation
     #
     # @return [void]
-    def time_operation(&block)
+    def time_operation(description, &block)
       start_time = Time.now
+      print "-----> #{description}"
       yield 
       puts " (#{(Time.now - start_time).duration})"
     end

--- a/lib/net_buildpack/buildpack.rb
+++ b/lib/net_buildpack/buildpack.rb
@@ -46,7 +46,8 @@ module NETBuildpack
           :diagnostics => {:directory => NETBuildpack::Util::Logger::DIAGNOSTICS_DIRECTORY},
           :runtime_home => '',
           :runtime_command => '',
-          :config_vars => {}
+          :config_vars => {},
+          :logger => @logger
       }
 
       @runtimes = Buildpack.construct_components(components, 'runtimes', @context, @logger)
@@ -256,7 +257,7 @@ module NETBuildpack
         container_list = Buildpack.component_detections(container_detections).join(', ')
         raise "Application can be run by more than one container: #{container_list}"
       end
-      
+
       container_detections
     end
 

--- a/lib/net_buildpack/buildpack.rb
+++ b/lib/net_buildpack/buildpack.rb
@@ -69,6 +69,8 @@ module NETBuildpack
       raise "Application can be run using more than one Runtime: #{runtime_detections.join(', ')}" if runtime_detections.size > 1
 
       container_detections = Buildpack.component_detections @containers
+      #Procfile container overrides all other container detections
+      container_detections = Buildpack.select_container_if_exists("net-procfile", container_detections)
       raise "Application can be run by more than one container: #{container_detections.join(', ')}" if container_detections.size > 1
 
      # framework_detections = Buildpack.component_detections @frameworks
@@ -179,6 +181,12 @@ module NETBuildpack
 
     def self.component_detections(components)
       components.map { |component| component.detect }.compact
+    end
+
+    #reduce container_array to named container if exists, otherwise return passed in containers 
+    def self.select_container_if_exists(container_name, all_containers)
+      procfile_containers = all_containers.select { |container| container == "#{container_name}" }
+      procfile_containers.size > 0 ? procfile_containers : all_containers
     end
 
     def self.configuration(app_dir, type, logger)

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -38,14 +38,13 @@ module NETBuildpack::Container
         sh "mkdir -p #{stage_time_absolute_path('vendor')}", {:silent => true}
         sh "cp #{file.path} #{stage_time_absolute_path('vendor/forego')}", {:silent => true}
       end
-    end
-
-    def release
 
       #otherwise CF runtime will use the web: element as the start command 
       #rather than the 'forego start' command we specify
       replace_in_file(find_file("Procfile"),"web:","_web:")
+    end
 
+    def release
       foreman_string = "#{runtime_time_absolute_path('vendor/forego')} start -p $PORT"
 
       "#{foreman_string}"

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -41,7 +41,10 @@ module NETBuildpack::Container
 
       #otherwise CF runtime will use the web: element as the start command 
       #rather than the 'forego start' command we specify
-      replace_in_file(find_file("Procfile"),"web:","_web:")
+      time_operation "Patching Procfile to rename web: to _web:" do
+        replace_in_file(find_file("Procfile"),"web:","_web:")
+      end
+      
     end
 
     def release

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -34,9 +34,9 @@ module NETBuildpack::Container
 
     def compile 
       download("current.linux-amd64", FOREGO_URI) do |file| 
-        sh "chmod +x #{file.path}"
-        sh "mkdir -p #{stage_time_absolute_path('vendor')}"
-        sh "cp #{file.path} #{stage_time_absolute_path('vendor/forego')}"  
+        sh "chmod +x #{file.path}", {:silent => true}
+        sh "mkdir -p #{stage_time_absolute_path('vendor')}", {:silent => true}
+        sh "cp #{file.path} #{stage_time_absolute_path('vendor/forego')}", {:silent => true}
       end
     end
 

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -1,0 +1,81 @@
+# Encoding: utf-8
+# Cloud Foundry NET Buildpack
+# Copyright 2013 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net_buildpack/container'
+require 'net_buildpack/container/container_utils'
+
+module NETBuildpack::Container
+
+  # Encapsulates the detect, compile, and release functionality for NET applications whose start command is embedded in a Procfile
+  # This isn't a _container_ in the traditional sense, but contains the functionality to manage a set of .NET applications working together
+  class Procfile 
+
+    # Creates an instance, passing in an arbitrary collection of options.
+    #
+    # @param [Hash] context the context that is provided to the instance
+    # @option context [String] :app_dir the directory that the application exists in
+    # @option context [String] :mono_home the directory that acts as +MONO_HOME+
+    # @option context [String] :lib_directory the directory that additional libraries are placed in
+    # @option context [Hash] :configuration the properties provided by the user
+    def initialize(context = {})
+      @app_dir = context[:app_dir]
+      @runtime_command = context[:runtime_command]
+      @lib_directory = context[:lib_directory]
+      @configuration = context[:configuration]
+    end
+
+    def detect
+      find_file("Procfile") ? id : nil
+    end
+
+    def compile 
+      download "current.linux-amd64", "https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego", "forego (Foreman in Go)" do |file|
+        system "chmod +x #{file.path}"
+        system "cp #{file.path} #{@lib_directory}/forego"  
+      end
+    end
+
+    def release
+      foreman_string = "#{relative_lib_directory}/forego start -p $PORT"
+
+      "#{foreman_string}"
+    end
+
+    private
+
+    ARGUMENTS_PROPERTY = 'arguments'.freeze
+
+    def arguments
+      @configuration[ARGUMENTS_PROPERTY]
+    end
+
+    def id
+      'net-procfile'
+    end
+
+    def find_file(filename)
+      filepath = File.join(@app_dir, filename)
+      filepath = File.exists?(filepath) ? filepath : nil
+      filepath
+    end
+
+    def relative_lib_directory
+      @lib_directory.sub! "#{@app_dir}/", './'
+    end
+
+  end
+
+end

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -47,12 +47,13 @@ module NETBuildpack::Container
       NETBuildpack::Util::ApplicationCache.new.get(FOREGO_URI) do |file|  
         puts "(#{(Time.now - download_start_time).duration})"
         system "chmod +x #{file.path}"
-        system "cp #{file.path} #{@lib_directory}/forego"  
+        system "mkdir -p #{stage_time_absolute_path('vendor')}"
+        system "cp #{file.path} #{stage_time_absolute_path('vendor/forego')}"  
       end
     end
 
     def release
-      foreman_string = "#{relative_lib_directory}/forego start -p $PORT"
+      foreman_string = "#{runtime_time_absolute_path('vendor/forego')} start -p $PORT"
 
       "#{foreman_string}"
     end
@@ -76,8 +77,12 @@ module NETBuildpack::Container
       filepath
     end
 
-    def relative_lib_directory
-      @lib_directory.sub! "#{@app_dir}/", './'
+    def stage_time_absolute_path(path)
+      File.join @app_dir, path
+    end
+
+    def runtime_time_absolute_path(path)
+      File.join "/app", path
     end
 
   end

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -42,7 +42,8 @@ module NETBuildpack::Container
     end
 
     def compile 
-      download "current.linux-amd64", "https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego", "forego (Foreman in Go)" do |file|
+      Downloading "-----> Downloading Forego 'current.linux-amd64' from #{FOREGO_URI} "
+      download "current.linux-amd64", FOREGO_URI, "forego (Foreman in Go)" do |file|
         system "chmod +x #{file.path}"
         system "cp #{file.path} #{@lib_directory}/forego"  
       end
@@ -57,6 +58,7 @@ module NETBuildpack::Container
     private
 
     ARGUMENTS_PROPERTY = 'arguments'.freeze
+    FOREGO_URI = 'https://godist.herokuapp.com/projects/ddollar/forego/releases/current/linux-amd64/forego'.freeze
 
     def arguments
       @configuration[ARGUMENTS_PROPERTY]

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -42,8 +42,10 @@ module NETBuildpack::Container
     end
 
     def compile 
-      Downloading "-----> Downloading Forego 'current.linux-amd64' from #{FOREGO_URI} "
-      download "current.linux-amd64", FOREGO_URI, "forego (Foreman in Go)" do |file|
+      download_start_time = Time.now
+      puts "-----> Downloading Forego 'current.linux-amd64' from #{FOREGO_URI} "
+      NETBuildpack::Util::ApplicationCache.new.get(FOREGO_URI) do |file|  
+        puts "(#{(Time.now - download_start_time).duration})"
         system "chmod +x #{file.path}"
         system "cp #{file.path} #{@lib_directory}/forego"  
       end

--- a/lib/net_buildpack/container/procfile.rb
+++ b/lib/net_buildpack/container/procfile.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'net_buildpack/base_component'
 require 'net_buildpack/container'
 require 'net_buildpack/container/container_utils'
 
@@ -21,7 +22,7 @@ module NETBuildpack::Container
 
   # Encapsulates the detect, compile, and release functionality for NET applications whose start command is embedded in a Procfile
   # This isn't a _container_ in the traditional sense, but contains the functionality to manage a set of .NET applications working together
-  class Procfile 
+  class Procfile < NETBuildpack::BaseComponent
 
     # Creates an instance, passing in an arbitrary collection of options.
     #
@@ -53,6 +54,11 @@ module NETBuildpack::Container
     end
 
     def release
+
+      #otherwise CF runtime will use the web: element as the start command 
+      #rather than the 'forego start' command we specify
+      replace_in_file(find_file("Procfile"),"web:","_web:")
+
       foreman_string = "#{runtime_time_absolute_path('vendor/forego')} start -p $PORT"
 
       "#{foreman_string}"

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -104,14 +104,6 @@ module NETBuildpack::Runtime
       "mono-#{version}"
     end
 
-    def stage_time_absolute_path(path)
-      File.join @app_dir, path
-    end
-
-    def runtime_time_absolute_path(path)
-      File.join "/app", path
-    end
-
     def mono_bin
       File.join MONO_HOME, 'bin'
     end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -71,7 +71,7 @@ module NETBuildpack::Runtime
     private
 
     MONO_HOME = 'vendor/mono'.freeze
-    
+
     def set_mono_config_vars
       @config_vars["LD_LIBRARY_PATH"] = "$HOME/#{mono_lib}:$LD_LIBRARY_PATH"
       @config_vars["DYLD_LIBRARY_FALLBACK_PATH"] = "$HOME/#{mono_lib}:$DYLD_LIBRARY_FALLBACK_PATH"
@@ -113,7 +113,7 @@ module NETBuildpack::Runtime
     end
 
     def mono_bin
-      File.join MONO_HOME, 'bin', 'mono'
+      File.join MONO_HOME, 'bin'
     end
 
     def mono_lib
@@ -128,7 +128,7 @@ module NETBuildpack::Runtime
     #
     # @return [String]
     def runtime_command
-      "$HOME/#{mono_bin} --server"
+      "$HOME/#{mono_bin}/mono --server"
     end
 
   end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require 'fileutils'
+require 'net_buildpack/base_component'
 require 'net_buildpack/runtime'
 require 'net_buildpack/runtime/stack'
 require 'net_buildpack/repository/configured_item'
@@ -24,26 +25,15 @@ require 'net_buildpack/util/tokenized_version'
 module NETBuildpack::Runtime
 
   # Encapsulates the detect, compile, and release functionality for selecting an Mono .NET runtime
-  class Mono
+  class Mono < NETBuildpack::BaseComponent
 
-    # Creates an instance, passing in an arbitrary collection of options.
-    #
-    # @param [Hash] context the context that is provided to the instance
-    # @option context [String] :app_dir the directory that the application exists in
-    # @option context [String] :runtime_command the command to launch the runtime
-    # @option context [Hash] :config_vars the config vars used to set the environment
-    # @option context [Hash] :configuration the properties provided by the user
-    # @option context [Hash] :diagnostics the diagnostics information provided by the buildpack
     def initialize(context)
-      @config_vars = context[:config_vars] 
-      @app_dir = context[:app_dir]
-      @configuration = context[:configuration]
-      @diagnostics_directory = context[:diagnostics][:directory] # Note this is a relative directory.
+      super('Mono runtime', context)
       @version, @uri = Mono.find_mono(@configuration)
 
       #concat seems to be the way to change the param
       context[:runtime_home].concat MONO_HOME
-      context[:runtime_command].concat runtime_command 
+      context[:runtime_command].concat runtime_command
     end
 
     # Detects which version of Mono this application should use.  
@@ -59,44 +49,39 @@ module NETBuildpack::Runtime
     #
     # @return [void]
     def compile
-      download_start_time = Time.now
-      print "-----> Downloading Mono #{@version} from #{@uri} "
+      download(@version, @uri) { |file| expand file }
 
-      NETBuildpack::Util::ApplicationCache.new.get(@uri) do |file|  # TODO Use global cache #50175265
-        puts "(#{(Time.now - download_start_time).duration})"
-        expand file
+      @config_vars["HOME"] = @app_dir
+      set_mono_config_vars
+
+      time_operation do
+        puts "-----> Installing Mozilla certificate data to .config/.mono/certs"
+        sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:env => @config_vars}
       end
-
-      download_start_time = Time.now
-      print "-----> Downloading Mozilla certificate data "
-      NETBuildpack::Util::ApplicationCache.new.get(MOZILLA_CERTS_URL) do |file|  
-        puts "(#{(Time.now - download_start_time).duration})"
-        add_cert_installation_to_startup file
-      end
-
-      system "echo 'ln -s #{runtime_time_absolute_path("vendor")} /app/vendor' >> #{stage_time_absolute_path(setup_mono)}"
-    end
+  end
 
     # Update config_vars
     #
     # @return [void]
     def release
-
-      @config_vars["LD_LIBRARY_PATH"] = "#{runtime_time_absolute_path(mono_lib)}:$LD_LIBRARY_PATH"
-      @config_vars["DYLD_LIBRARY_FALLBACK_PATH"] = "#{runtime_time_absolute_path(mono_lib)}:$DYLD_LIBRARY_FALLBACK_PATH"
-      @config_vars["PKG_CONFIG_PATH"] = "#{runtime_time_absolute_path(File.join(mono_lib,'pkgconfig'))}:$PKG_CONFIG_PATH"
-      @config_vars["C_INCLUDE_PATH"] = "#{runtime_time_absolute_path(File.join(MONO_HOME,'include'))}:$C_INCLUDE_PATH"
-      @config_vars["ACLOCAL_PATH"] = "#{runtime_time_absolute_path(File.join(MONO_HOME,'share','aclocal'))}:$ACLOCAL_PATH"
-      @config_vars["PATH"] = "#{runtime_time_absolute_path(mono_bin)}:$PATH"
-      @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
-      @config_vars["XDG_CONFIG_HOME"] = "#{runtime_time_absolute_path('vendor')}"
-
+      set_mono_config_vars
     end
 
     private
 
     MONO_HOME = 'vendor/mono'.freeze
     MOZILLA_CERTS_URL = "http://mxr.mozilla.org/seamonkey/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1"
+
+    def set_mono_config_vars
+      @config_vars["LD_LIBRARY_PATH"] = "$HOME/#{mono_lib}:$LD_LIBRARY_PATH"
+      @config_vars["DYLD_LIBRARY_FALLBACK_PATH"] = "$HOME/#{mono_lib}:$DYLD_LIBRARY_FALLBACK_PATH"
+      @config_vars["PKG_CONFIG_PATH"] = "$HOME/#{File.join(mono_lib,'pkgconfig')}:$PKG_CONFIG_PATH"
+      @config_vars["C_INCLUDE_PATH"] = "$HOME/#{File.join(MONO_HOME,'include')}:$C_INCLUDE_PATH"
+      @config_vars["ACLOCAL_PATH"] = "$HOME/#{File.join(MONO_HOME,'share','aclocal')}:$ACLOCAL_PATH"
+      @config_vars["PATH"] = "$HOME/#{mono_bin}:$PATH"
+      @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
+      @config_vars["XDG_CONFIG_HOME"] = "$HOME"
+    end
 
     def expand(file)
       expand_start_time = Time.now
@@ -107,12 +92,6 @@ module NETBuildpack::Runtime
       system "tar xzf #{file.path} -C #{stage_time_absolute_path(MONO_HOME)} --strip 1 2>&1"
 
       puts "(#{(Time.now - expand_start_time).duration})"
-    end
-
-    def add_cert_installation_to_startup(file)
-      FileUtils.move file, File.join( @app_dir, mozilla_certs_file )
-      system "echo '#{mozroots_exe} --import --sync --file #{mozilla_certs_file}' >> #{stage_time_absolute_path(setup_mono)}"
-      system "chmod +x #{stage_time_absolute_path(setup_mono)}"
     end
 
     def self.find_mono(configuration)
@@ -141,14 +120,6 @@ module NETBuildpack::Runtime
       File.join MONO_HOME, 'lib' 
     end
 
-    def setup_mono
-      File.join MONO_HOME, 'bin', 'setup_mono'
-    end 
-
-    def mozilla_certs_file
-      File.join MONO_HOME, "mozilla_certsdata.txt"
-    end
-
     def mozroots_exe
       File.join MONO_HOME, 'bin', 'mozroots'
     end
@@ -157,7 +128,7 @@ module NETBuildpack::Runtime
     #
     # @return [String]
     def runtime_command
-      "#{runtime_time_absolute_path(setup_mono)} && #{runtime_time_absolute_path(mono_bin)} --server"
+      "$HOME/#{mono_bin} --server"
     end
 
   end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -67,6 +67,7 @@ module NETBuildpack::Runtime
         expand file
       end
 
+      download_start_time = Time.now
       print "-----> Downloading Mozilla certificate data "
       NETBuildpack::Util::ApplicationCache.new.get(MOZILLA_CERTS_URL) do |file|  
         puts "(#{(Time.now - download_start_time).duration})"

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -80,7 +80,7 @@ module NETBuildpack::Runtime
       @config_vars["ACLOCAL_PATH"] = "$HOME/#{File.join(MONO_HOME,'share','aclocal')}:$ACLOCAL_PATH"
       @config_vars["PATH"] = "/usr/local/bin:/usr/bin:/bin:$HOME/#{mono_bin}:$PATH"
       @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
-      @config_vars["XDG_CONFIG_HOME"] = "$HOME"
+      @config_vars["XDG_CONFIG_HOME"] = "$HOME/.config"
     end
 
     def expand(file)

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -89,6 +89,7 @@ module NETBuildpack::Runtime
       @config_vars["ACLOCAL_PATH"] = "#{runtime_time_absolute_path(File.join(MONO_HOME,'share','aclocal'))}:$ACLOCAL_PATH"
       @config_vars["PATH"] = "#{runtime_time_absolute_path(mono_bin)}:$PATH"
       @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
+      @config_vars["XDG_CONFIG_HOME"] = "#{runtime_time_absolute_path('vendor')}"
 
     end
 

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -56,6 +56,7 @@ module NETBuildpack::Runtime
 
       time_operation do
         puts "-----> Installing Mozilla certificate data to .config/.mono/certs"
+        sh "/usr/bin/env", {:env => @config_vars}
         sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:env => @config_vars}
         sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:env => @config_vars}
       end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -56,8 +56,8 @@ module NETBuildpack::Runtime
 
       time_operation do
         puts "-----> Installing Mozilla certificate data to .config/.mono/certs"
-        sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:env => @config_vars}
-        sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:env => @config_vars}
+        sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:silent => true, :env => @config_vars}
+        sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:silent => true, :env => @config_vars}
       end
   end
 

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -56,7 +56,6 @@ module NETBuildpack::Runtime
 
       time_operation do
         puts "-----> Installing Mozilla certificate data to .config/.mono/certs"
-        sh "/usr/bin/env", {:env => @config_vars}
         sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:env => @config_vars}
         sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:env => @config_vars}
       end
@@ -72,8 +71,7 @@ module NETBuildpack::Runtime
     private
 
     MONO_HOME = 'vendor/mono'.freeze
-    MOZILLA_CERTS_URL = "http://mxr.mozilla.org/seamonkey/source/security/nss/lib/ckfw/builtins/certdata.txt?raw=1"
-
+    
     def set_mono_config_vars
       @config_vars["LD_LIBRARY_PATH"] = "$HOME/#{mono_lib}:$LD_LIBRARY_PATH"
       @config_vars["DYLD_LIBRARY_FALLBACK_PATH"] = "$HOME/#{mono_lib}:$DYLD_LIBRARY_FALLBACK_PATH"

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -54,8 +54,7 @@ module NETBuildpack::Runtime
       @config_vars["HOME"] = @app_dir
       set_mono_config_vars
 
-      time_operation do
-        print "-----> Installing Mozilla certificate data to .config/.mono/certs"
+      time_operation "Installing Mozilla certificate data to .config/.mono/certs" do
         sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:silent => true, :env => @config_vars}
         sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:silent => true, :env => @config_vars}
       end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -80,7 +80,7 @@ module NETBuildpack::Runtime
       @config_vars["PKG_CONFIG_PATH"] = "$HOME/#{File.join(mono_lib,'pkgconfig')}:$PKG_CONFIG_PATH"
       @config_vars["C_INCLUDE_PATH"] = "$HOME/#{File.join(MONO_HOME,'include')}:$C_INCLUDE_PATH"
       @config_vars["ACLOCAL_PATH"] = "$HOME/#{File.join(MONO_HOME,'share','aclocal')}:$ACLOCAL_PATH"
-      @config_vars["PATH"] = "$HOME/#{mono_bin}:$PATH"
+      @config_vars["PATH"] = "/usr/local/bin:/usr/bin:/bin:$HOME/#{mono_bin}:$PATH"
       @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
       @config_vars["XDG_CONFIG_HOME"] = "$HOME"
     end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -55,7 +55,7 @@ module NETBuildpack::Runtime
       set_mono_config_vars
 
       time_operation do
-        puts "-----> Installing Mozilla certificate data to .config/.mono/certs"
+        print "-----> Installing Mozilla certificate data to .config/.mono/certs"
         sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:silent => true, :env => @config_vars}
         sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:silent => true, :env => @config_vars}
       end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -56,6 +56,7 @@ module NETBuildpack::Runtime
 
       time_operation do
         puts "-----> Installing Mozilla certificate data to .config/.mono/certs"
+        sh "ln -s #{stage_time_absolute_path("vendor")} /app/vendor", {:env => @config_vars}
         sh "#{stage_time_absolute_path(mozroots_exe)} --import --sync", {:env => @config_vars}
       end
   end

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -87,6 +87,7 @@ module NETBuildpack::Runtime
       @config_vars["C_INCLUDE_PATH"] = "#{runtime_time_absolute_path(File.join(MONO_HOME,'include'))}:$C_INCLUDE_PATH"
       @config_vars["ACLOCAL_PATH"] = "#{runtime_time_absolute_path(File.join(MONO_HOME,'share','aclocal'))}:$ACLOCAL_PATH"
       @config_vars["PATH"] = "#{runtime_time_absolute_path(mono_bin)}:$PATH"
+      @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
 
     end
 

--- a/lib/net_buildpack/util/logger.rb
+++ b/lib/net_buildpack/util/logger.rb
@@ -64,4 +64,10 @@ module NETBuildpack::Util
 
   end
 
+  class NullLogger
+    def log(title, data = nil)
+      #no-op
+    end
+  end
+
 end

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -24,11 +24,12 @@ module NETBuildpack::Util
 
 		def self.exec(cmd, logger, options = {})
 			options[:silent] ||= false
+			options[:env] ||= {}
 			exit_value = 0
 			is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
 			if is_windows then 
 			  require 'open3'
-     	  Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
+     	  Open3.popen3(options[:env], cmd) do |stdin, stdout, stderr, wait_thr|
           exit_value = wait_thr.value.to_i
           output = "#{cmd}, exit code: #{exit_value}, output: #{stdout.read}\n#{stderr.read}"
           logger.log output
@@ -47,7 +48,7 @@ module NETBuildpack::Util
 	  	  	cmd = cmd_file.path
 	  	  	File.chmod(0744, cmd)
 	  	  end
-			  PTY.spawn( cmd ) do |stdout_and_err, stdin, pid| 
+			  PTY.spawn(options[:env], cmd ) do |stdout_and_err, stdin, pid| 
 			  	begin
 			      stdout_and_err.each do |line| 
 			      	output += line

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -26,11 +26,11 @@ module NETBuildpack::Util
   
   	# Expands variables that contain other variables in the hash.
   	#
-  	# eg:  expand_variables { "HOME"=>"/home/foo", "CONFIG"=>"$HOME/config"}
-  	#  => { "HOME"=>"/home/foo", "CONFIG"=>"/home/foo/config"}
+  	# eg:  expand_variables { "HOME"=>"/home/foo", "CONFIG"=>"$HOME/config", "PATH"=>"/new/path:$PATH"}
+  	#  => { "HOME"=>"/home/foo", "CONFIG"=>"/home/foo/config", "PATH"=>"/new/path:$PATH"}
 	  def self.expand_variables(env)
 	  	env.merge(env) do |key,value| 
-	  		value.gsub(VARIABLES_REGEX) { env[$1] } 	
+	  		value.gsub(VARIABLES_REGEX) { $1==key ? "$#{key}" : env[$1] } 	
 	  	end
 	  end
 

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -26,6 +26,8 @@ module NETBuildpack::Util
 			options[:silent] ||= false
 			options[:env] ||= {}
 			exit_value = 0
+			output = "With ENV:\n#{options[:env].inspect}\n\nexec '#{cmd}':\n\n"
+	  	puts cmd unless options[:silent]
 			is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
 			if is_windows then 
 			  require 'open3'
@@ -37,8 +39,6 @@ module NETBuildpack::Util
         end
 		  else
 	  	  require 'pty'
-	  	  output = "#{cmd} ==>\n\n"
-	  	  puts cmd unless options[:silent]
 	  	  #Wrap bash commands in a script so that PTY.spawn will run them.
 	  	  unless File.exists?(cmd)
 	  	  	cmd_file = Tempfile.new('net_buildpack_run_command.sh')

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -42,7 +42,7 @@ module NETBuildpack::Util
 	  	  #Wrap bash commands in a script so that PTY.spawn will run them.
 	  	  unless File.exists?(cmd)
 	  	  	cmd_file = Tempfile.new('net_buildpack_run_command.sh')
-	  	  	cmd_file.write("#!/bin/bash\n")
+	  	  	cmd_file.write("#!/usr/bin/env bash\n")
 	  	  	cmd_file.write(cmd)
 	  	  	cmd_file.close
 	  	  	cmd = cmd_file.path

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -42,7 +42,7 @@ module NETBuildpack::Util
 	  	  #Wrap bash commands in a script so that PTY.spawn will run them.
 	  	  unless File.exists?(cmd)
 	  	  	cmd_file = Tempfile.new('net_buildpack_run_command.sh')
-	  	  	cmd_file.write("#!/usr/bin/env bash\n")
+	  	  	cmd_file.write("#!/bin/bash\n")
 	  	  	cmd_file.write(cmd)
 	  	  	cmd_file.close
 	  	  	cmd = cmd_file.path

--- a/lib/net_buildpack/util/run_command.rb
+++ b/lib/net_buildpack/util/run_command.rb
@@ -22,9 +22,22 @@ module NETBuildpack::Util
   # Run external shell commands, both streaming and logging output
   class RunCommand
 
+  	VARIABLES_REGEX = /\$([a-zA-Z_]+[a-zA-Z0-9_]*)|\$\{(.+)\}/
+  
+  	# Expands variables that contain other variables in the hash.
+  	#
+  	# eg:  expand_variables { "HOME"=>"/home/foo", "CONFIG"=>"$HOME/config"}
+  	#  => { "HOME"=>"/home/foo", "CONFIG"=>"/home/foo/config"}
+	  def self.expand_variables(env)
+	  	env.merge(env) do |key,value| 
+	  		value.gsub(VARIABLES_REGEX) { env[$1] } 	
+	  	end
+	  end
+
 		def self.exec(cmd, logger, options = {})
 			options[:silent] ||= false
 			options[:env] ||= {}
+			options[:env] = expand_variables options[:env]
 			exit_value = 0
 			output = "With ENV:\n#{options[:env].inspect}\n\nexec '#{cmd}':\n\n"
 	  	puts cmd unless options[:silent]

--- a/spec/bin/compile_spec.rb
+++ b/spec/bin/compile_spec.rb
@@ -18,8 +18,9 @@ require 'spec_helper'
 require 'open3'
 require 'tmpdir'
 
+# WARNING.  This takes ages to run the *first* time since it downloads a 60MB mono runtime tar.gz
 describe 'compile script', :integration do
-	it 'should return zero if success' do # WARNING.  This takes ages to run the first time since it downloads a 60MB mono runtime tar.gz
+	it 'should return zero if success' do 
     Dir.mktmpdir do |root|
       FileUtils.cp_r 'spec/fixtures/integration_valid/.', root
       cache_dir =  File.join Dir.tmpdir, ".net_buildpack_cache_dir"
@@ -34,6 +35,24 @@ describe 'compile script', :integration do
       end
       # puts `cat #{root}/.buildpack-diagnostics/buildpack.log`
       # puts `tree -a #{root}`
+    end
+  end
+
+  it 'should successfully compile an app with a Procfile container' do 
+    Dir.mktmpdir do |root|
+      FileUtils.cp_r 'spec/fixtures/procfile/.', root
+      cache_dir =  File.join Dir.tmpdir, ".net_buildpack_cache_dir"
+      FileUtils.mkdir_p cache_dir
+
+      with_memory_limit('1G') do
+        Open3.popen3("bin/compile #{root} #{cache_dir}") do |stdin, stdout, stderr, wait_thr|
+           exit_value = wait_thr.value
+           puts "#{stdout.read}\n#{stderr.read}" if exit_value != 0
+           expect(exit_value).to be_success
+        end
+      end
+      #puts `cat #{root}/.buildpack-diagnostics/buildpack.log`
+      #puts `tree -a #{root}`
     end
   end
 

--- a/spec/bin/detect_spec.rb
+++ b/spec/bin/detect_spec.rb
@@ -41,6 +41,22 @@ describe 'detect script', :integration do
     end
   end
 
+  it 'should handle Procfile' do
+     Dir.mktmpdir do |root|
+      FileUtils.cp_r 'spec/fixtures/procfile/.', root
+      with_memory_limit('1G') do
+        Open3.popen3("bin/detect #{root}") do |stdin, stdout, stderr, wait_thr|
+          exit_code = wait_thr.value
+          result = stdout.read
+          puts result if exit_code != 0
+          expect(wait_thr.value).to be_success
+          expect(result).to include("net-procfile")
+          expect(result).to_not include("console")
+        end
+      end
+    end
+  end
+
   def with_memory_limit(memory_limit)
     previous_value = ENV['MEMORY_LIMIT']
     begin

--- a/spec/bin/release_spec.rb
+++ b/spec/bin/release_spec.rb
@@ -41,7 +41,7 @@ describe 'release script', :integration do
       with_memory_limit('1G') do
         Open3.popen3("bin/release #{root}") do |stdin, stdout, stderr, wait_thr|
            exit_value = wait_thr.value
-           expect(stdout.read).to include('web: /app/vendor/mono/bin/setup_mono && /app/vendor/mono/bin/mono --server z-Start.exe')
+           expect(stdout.read).to include('web: $HOME/vendor/mono/bin/mono --server z-Start.exe')
         end
       end
 

--- a/spec/fixtures/procfile/.cfignore
+++ b/spec/fixtures/procfile/.cfignore
@@ -1,0 +1,7 @@
+tmp/
+obj/
+myapp-web/
+myapp-worker/
+packages/
+*.sln
+*.userprefs

--- a/spec/fixtures/procfile/.gitignore
+++ b/spec/fixtures/procfile/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+bin/
+obj/
+packages/
+*.userprefs

--- a/spec/fixtures/procfile/Procfile
+++ b/spec/fixtures/procfile/Procfile
@@ -1,2 +1,2 @@
-web: $RUNTIME_COMMAND bin/myapp-web.exe -port $PORT
-worker: $RUNTIME_COMMAND bin/myapp-worker.exe
+web: mono bin/myapp-web.exe -port $PORT
+worker: mono bin/myapp-worker.exe

--- a/spec/fixtures/procfile/Procfile
+++ b/spec/fixtures/procfile/Procfile
@@ -1,0 +1,2 @@
+web: $RUNTIME_COMMAND bin/myapp-web.exe -port $PORT
+worker: $RUNTIME_COMMAND bin/myapp-worker.exe

--- a/spec/fixtures/procfile/bin/myapp-web.exe.config
+++ b/spec/fixtures/procfile/bin/myapp-web.exe.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+</configuration>

--- a/spec/fixtures/procfile/manifest.yml
+++ b/spec/fixtures/procfile/manifest.yml
@@ -1,0 +1,7 @@
+---
+applications:
+- name: net-buildpack-procfile-sample
+  buildpack: https://github.com/cloudfoundry-community/.net-buildpack
+  memory: 256
+  instances: 1
+  path: .

--- a/spec/fixtures/procfile/myapp-web/Program.cs
+++ b/spec/fixtures/procfile/myapp-web/Program.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Threading;
+using Nancy.Hosting.Self;
+using Nancy;
+
+namespace NancyFXSample
+{
+	class MainClass
+	{
+		public static void Main (string[] args)
+		{
+			var baseUri = new Uri (String.Format("http://0.0.0.0:{0}", System.Environment.GetEnvironmentVariable("PORT")));
+			var nancyHost = new NancyHost (baseUri);
+
+			nancyHost.Start ();
+			Console.WriteLine ("Nancy Listening on {0}", baseUri.AbsoluteUri);
+
+			while (1==1) {
+				Thread.Sleep (10);
+			}
+		}
+
+		public class HelloModule : NancyModule
+		{
+			public HelloModule()
+			{
+				Get["/"] = parameters => "Hello World";
+			}
+		}
+	}
+}

--- a/spec/fixtures/procfile/myapp-web/Properties/AssemblyInfo.cs
+++ b/spec/fixtures/procfile/myapp-web/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the values specific to your project.
+[assembly: AssemblyTitle ("myapp-web")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("mrdavidlaing")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+[assembly: AssemblyVersion ("1.0.*")]
+// The following attributes are used to specify the signing key for the assembly, 
+// if desired. See the Mono documentation for more information about signing.
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/spec/fixtures/procfile/myapp-web/app.config
+++ b/spec/fixtures/procfile/myapp-web/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+</configuration>

--- a/spec/fixtures/procfile/myapp-web/myapp-web.csproj
+++ b/spec/fixtures/procfile/myapp-web/myapp-web.csproj
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E554C97C-7656-4C86-922A-18CBDF67B905}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>myapp-web</RootNamespace>
+    <AssemblyName>myapp-web</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+    <EnvironmentVariables>
+      <EnvironmentVariables>
+        <Variable name="PORT" value="3000" />
+      </EnvironmentVariables>
+    </EnvironmentVariables>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Nancy">
+      <HintPath>..\packages\Nancy.0.18.0\lib\net40\Nancy.dll</HintPath>
+    </Reference>
+    <Reference Include="Nancy.Hosting.Self">
+      <HintPath>..\packages\Nancy.Hosting.Self.0.18.0\lib\net40\Nancy.Hosting.Self.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+</Project>

--- a/spec/fixtures/procfile/myapp-web/packages.config
+++ b/spec/fixtures/procfile/myapp-web/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Nancy" version="0.18.0" targetFramework="net40" />
+  <package id="Nancy.Hosting.Self" version="0.18.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
+</packages>

--- a/spec/fixtures/procfile/myapp-worker/Program.cs
+++ b/spec/fixtures/procfile/myapp-worker/Program.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+
+namespace myappworker
+{
+	class MainClass
+	{
+		public static void Main (string[] args)
+		{
+			var wait = Convert.ToInt32(TimeSpan.FromSeconds(30).TotalMilliseconds);
+
+			while (1==1) {
+				Console.WriteLine ("Doing work! ...");
+				Thread.Sleep (wait);
+			}
+		}
+	}
+}

--- a/spec/fixtures/procfile/myapp-worker/Properties/AssemblyInfo.cs
+++ b/spec/fixtures/procfile/myapp-worker/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+[assembly: AssemblyTitle ("myapp-worker")]
+[assembly: AssemblyDescription ("")]
+[assembly: AssemblyConfiguration ("")]
+[assembly: AssemblyCompany ("")]
+[assembly: AssemblyProduct ("")]
+[assembly: AssemblyCopyright ("mrdavidlaing")]
+[assembly: AssemblyTrademark ("")]
+[assembly: AssemblyCulture ("")]
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+[assembly: AssemblyVersion ("1.0.*")]
+// The following attributes are used to specify the signing key for the assembly,
+// if desired. See the Mono documentation for more information about signing.
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/spec/fixtures/procfile/myapp-worker/myapp-worker.csproj
+++ b/spec/fixtures/procfile/myapp-worker/myapp-worker.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A2D558B7-C5F8-4598-8633-5FF9180123F6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>myappworker</RootNamespace>
+    <AssemblyName>myapp-worker</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\bin</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Externalconsole>true</Externalconsole>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/spec/fixtures/procfile/myapp.sln
+++ b/spec/fixtures/procfile/myapp.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "myapp-web", "myapp-web\myapp-web.csproj", "{E554C97C-7656-4C86-922A-18CBDF67B905}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{9C9D4872-55D0-4E3F-AF8D-3427AB039ECE}"
+	ProjectSection(SolutionItems) = preProject
+		manifest.yml = manifest.yml
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "myapp-worker", "myapp-worker\myapp-worker.csproj", "{A2D558B7-C5F8-4598-8633-5FF9180123F6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A2D558B7-C5F8-4598-8633-5FF9180123F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2D558B7-C5F8-4598-8633-5FF9180123F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2D558B7-C5F8-4598-8633-5FF9180123F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2D558B7-C5F8-4598-8633-5FF9180123F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E554C97C-7656-4C86-922A-18CBDF67B905}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E554C97C-7656-4C86-922A-18CBDF67B905}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E554C97C-7656-4C86-922A-18CBDF67B905}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E554C97C-7656-4C86-922A-18CBDF67B905}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = myapp-web\myapp-web.csproj
+	EndGlobalSection
+EndGlobal

--- a/spec/fixtures/procfile/packages/repositories.config
+++ b/spec/fixtures/procfile/packages/repositories.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<repositories>
+  <repository path="../CloudFoundry.Mono/packages.config" />
+  <repository path="../NancyFXSample/packages.config" />
+</repositories>

--- a/spec/net_buildpack/base_component_spec.rb
+++ b/spec/net_buildpack/base_component_spec.rb
@@ -1,0 +1,53 @@
+# Encoding: utf-8
+# Cloud Foundry NET Buildpack
+# Copyright 2013 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'net_buildpack/base_component'
+
+module NETBuildpack
+
+  describe BaseComponent do
+
+    let(:context) { { 'foo' => 'bar' } }
+    let(:base_component) { StubBaseComponent.new 'test-name', context }
+
+    it 'should assign component name to an instance variable' do
+      expect(base_component.component_name).to eq('test-name')
+    end
+
+    it 'should assign context to an instance variable' do
+      expect(base_component.context).to eq(context)
+    end
+
+    it 'should assign context items to instance variables' do
+      expect(base_component.foo).to eq(context['foo'])
+    end
+
+    it 'should fail if methods are unimplemented' do
+      expect { base_component.detect }.to raise_error
+      expect { base_component.compile }.to raise_error
+      expect { base_component.release }.to raise_error
+    end
+
+  end
+
+  class StubBaseComponent < BaseComponent
+
+    attr_reader :component_name, :context, :foo
+
+  end
+
+end

--- a/spec/net_buildpack/container/procfile_spec.rb
+++ b/spec/net_buildpack/container/procfile_spec.rb
@@ -40,7 +40,7 @@ module NETBuildpack::Container
             lib_directory: lib_directory
         ).release
 
-        expect(command).to include('./vendor/forego start -p $PORT')
+        expect(command).to include('/app/vendor/forego start -p $PORT')
       end
     end
 

--- a/spec/net_buildpack/container/procfile_spec.rb
+++ b/spec/net_buildpack/container/procfile_spec.rb
@@ -22,6 +22,11 @@ module NETBuildpack::Container
 
   describe Procfile do
 
+    before do
+      $stdout = StringIO.new
+      $stderr = StringIO.new
+    end
+
     it 'should detect with Procfile' do
       detected = Procfile.new(
           app_dir: 'spec/fixtures/procfile'
@@ -30,9 +35,8 @@ module NETBuildpack::Container
       expect(detected).to be_true
     end
 
-    it 'should return command' do
+    it 'should return forego command' do
       Dir.mktmpdir do |root|
-        procfile = create_procfile root
 
         lib_directory = File.join(root, 'vendor')
         Dir.mkdir lib_directory
@@ -51,9 +55,13 @@ module NETBuildpack::Container
       Dir.mktmpdir do |root|
         procfile = create_procfile root
 
-        command = Procfile.new(
+        container = Procfile.new(
             app_dir: root
-        ).release
+        )
+
+        container.stub(:download) #just ignore
+
+        container.compile
 
         expect(File.read(procfile)).to eq('_web: mono --server myapp-web.exe')
       end

--- a/spec/net_buildpack/container/procfile_spec.rb
+++ b/spec/net_buildpack/container/procfile_spec.rb
@@ -1,0 +1,49 @@
+# Encoding: utf-8
+# Cloud Foundry NET Buildpack
+# Copyright 2013 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'fileutils'
+require 'net_buildpack/container/procfile'
+
+module NETBuildpack::Container
+
+  describe Procfile do
+
+    it 'should detect with Procfile' do
+      detected = Procfile.new(
+          app_dir: 'spec/fixtures/procfile'
+      ).detect
+
+      expect(detected).to be_true
+    end
+
+    it 'should return command' do
+      Dir.mktmpdir do |root|
+        lib_directory = File.join(root, 'vendor')
+        Dir.mkdir lib_directory
+
+        command = Procfile.new(
+            app_dir: root,
+            lib_directory: lib_directory
+        ).release
+
+        expect(command).to include('./vendor/forego start -p $PORT')
+      end
+    end
+
+  end
+
+end

--- a/spec/net_buildpack/container/procfile_spec.rb
+++ b/spec/net_buildpack/container/procfile_spec.rb
@@ -32,8 +32,8 @@ module NETBuildpack::Container
 
     it 'should return command' do
       Dir.mktmpdir do |root|
-        procfile = create_procfile
-        
+        procfile = create_procfile root
+
         lib_directory = File.join(root, 'vendor')
         Dir.mkdir lib_directory
 
@@ -49,7 +49,7 @@ module NETBuildpack::Container
     #otherwise CF runtime will use the web: element as the start command rather than the 'forego start' command we specify
     it 'web: element in Procfile should be changed to _web:' do
       Dir.mktmpdir do |root|
-        procfile = create_procfile
+        procfile = create_procfile root
 
         command = Procfile.new(
             app_dir: root
@@ -59,8 +59,8 @@ module NETBuildpack::Container
       end
     end
 
-    def create_procfile
-      procfile = File.join root, 'Procfile'
+    def create_procfile(app_dir)
+      procfile = File.join app_dir, 'Procfile'
       File.open(procfile, 'w') { |f| f.write("web: mono --server myapp-web.exe")}
       procfile
     end

--- a/spec/net_buildpack/container/procfile_spec.rb
+++ b/spec/net_buildpack/container/procfile_spec.rb
@@ -32,6 +32,8 @@ module NETBuildpack::Container
 
     it 'should return command' do
       Dir.mktmpdir do |root|
+        procfile = create_procfile
+        
         lib_directory = File.join(root, 'vendor')
         Dir.mkdir lib_directory
 
@@ -44,6 +46,24 @@ module NETBuildpack::Container
       end
     end
 
+    #otherwise CF runtime will use the web: element as the start command rather than the 'forego start' command we specify
+    it 'web: element in Procfile should be changed to _web:' do
+      Dir.mktmpdir do |root|
+        procfile = create_procfile
+
+        command = Procfile.new(
+            app_dir: root
+        ).release
+
+        expect(File.read(procfile)).to eq('_web: mono --server myapp-web.exe')
+      end
+    end
+
+    def create_procfile
+      procfile = File.join root, 'Procfile'
+      File.open(procfile, 'w') { |f| f.write("web: mono --server myapp-web.exe")}
+      procfile
+    end
   end
 
 end

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -160,7 +160,7 @@ module NETBuildpack::Runtime
         expect(config_vars["C_INCLUDE_PATH"]).to include("$HOME/vendor/mono/include")
         expect(config_vars["ACLOCAL_PATH"]).to include("$HOME/vendor/mono/share/aclocal")
         expect(config_vars["PKG_CONFIG_PATH"]).to include("$HOME/vendor/mono/lib/pkgconfig")
-        expect(config_vars["PATH"]).to include("$HOME/vendor/mono/bin")
+        expect(config_vars["PATH"]).to include("/usr/local/bin:/usr/bin:/bin:$HOME/vendor/mono/bin")
         expect(config_vars["RUNTIME_COMMAND"]).to include("$HOME/vendor/mono/bin/mono")
         expect(config_vars["XDG_CONFIG_HOME"]).to include("$HOME")
       end

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -20,7 +20,7 @@ require 'net_buildpack/runtime/mono'
 
 module NETBuildpack::Runtime
 
-  describe Mono do
+  describe Mono  do
 
     DETAILS = [NETBuildpack::Util::TokenizedVersion.new('3.2.0'), 'test-uri']
 
@@ -189,6 +189,7 @@ module NETBuildpack::Runtime
         expect(config_vars["ACLOCAL_PATH"]).to include("/app/vendor/mono/share/aclocal")
         expect(config_vars["PKG_CONFIG_PATH"]).to include("/app/vendor/mono/lib/pkgconfig")
         expect(config_vars["PATH"]).to include("/app/vendor/mono/bin")
+        expect(config_vars["RUNTIME_COMMAND"]).to include("/app/vendor/mono/bin/mono")
       end
     end
 

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -162,7 +162,7 @@ module NETBuildpack::Runtime
         expect(config_vars["PKG_CONFIG_PATH"]).to include("$HOME/vendor/mono/lib/pkgconfig")
         expect(config_vars["PATH"]).to include("/usr/local/bin:/usr/bin:/bin:$HOME/vendor/mono/bin")
         expect(config_vars["RUNTIME_COMMAND"]).to include("$HOME/vendor/mono/bin/mono")
-        expect(config_vars["XDG_CONFIG_HOME"]).to include("$HOME")
+        expect(config_vars["XDG_CONFIG_HOME"]).to include("$HOME/.config")
       end
     end
 

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -107,11 +107,17 @@ module NETBuildpack::Runtime
       Dir.mktmpdir do |root|
 
         NETBuildpack::Util::RunCommand.stub(:exec) do |cmd, logger, options|
-        cmd.should include('mozroots')
-        cmd.should include('--import')
-        cmd.should include('--sync')
-        options[:env].should include('HOME'=>root, 'XDG_CONFIG_HOME' => '$HOME')
-        0
+            case cmd
+            when /ln.+/i
+                cmd.should include('-s')
+                cmd.should include("#{root}/vendor /app/vendor")
+            when /.*mozroots.*/i
+                cmd.should include('mozroots')
+                cmd.should include('--import')
+                cmd.should include('--sync')
+                options[:env].should include('HOME'=>root, 'XDG_CONFIG_HOME' => '$HOME/.config')
+            end
+            0
         end
 
         detected = Mono.new(

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -43,6 +43,14 @@ module NETBuildpack::Util
       expect(exit_value).to eq(0)
     end
 
+    it 'can be run with a custom ENV' do
+      logger.should_receive(:log) do |msg|
+        msg.should include('BAR')
+      end
+
+      exit_value = NETBuildpack::Util::RunCommand.exec("echo $FOO", logger, { :silent => true, :env => {"FOO" => "BAR"} })
+      expect(exit_value).to eq(0)
+    end
 
   end
 

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -45,10 +45,19 @@ module NETBuildpack::Util
 
     it 'can be run with a custom ENV' do
       logger.should_receive(:log) do |msg|
-        msg.should include('BAR')
+        msg.should include('FOO:BAR')
       end
 
-      exit_value = NETBuildpack::Util::RunCommand.exec("echo $FOO", logger, { :silent => true, :env => {"FOO" => "BAR"} })
+      exit_value = NETBuildpack::Util::RunCommand.exec("echo FOO:$FOO", logger, { :silent => true, :env => {"FOO" => "BAR"} })
+      expect(exit_value).to eq(0)
+    end
+
+    it 'custom ENV vars can reference other ENV vars' do
+      logger.should_receive(:log) do |msg|
+        msg.should include('ENV2:ONE,TWO')
+      end
+
+      exit_value = NETBuildpack::Util::RunCommand.exec("echo ENV2:$ENV2", logger, { :silent => true, :env => {"ENV1" => "ONE", "ENV2" => "$ENV1,TWO"} })
       expect(exit_value).to eq(0)
     end
 

--- a/spec/net_buildpack/util/run_command_spec.rb
+++ b/spec/net_buildpack/util/run_command_spec.rb
@@ -61,6 +61,15 @@ module NETBuildpack::Util
       expect(exit_value).to eq(0)
     end
 
+    it 'custom ENV vars can reference themselves' do
+      logger.should_receive(:log) do |msg|
+        msg.should include('ENV1:ONE,$ENV1')
+      end
+
+      exit_value = NETBuildpack::Util::RunCommand.exec("echo ENV1:$ENV1", logger, { :silent => true, :env => {"ENV1" => "ONE,$ENV1"} })
+      expect(exit_value).to eq(0)
+    end
+
   end
 
 end


### PR DESCRIPTION
This includes:
1.  Refactoring common component code out into base_component.rb
2.  Installing the mozroots to `app/.config` at staging time (rather than runtime)
3.  Removal of the `setup_mono.sh` that had to be run at startup time
4.  The addition of the Procfile container, which enables multiple startup commands to be specified in a `Procfile` ala [ddollar/foreman](https://github.com/ddollar/foreman)
