### PR TITLE
NETBuildpack::Runtime::Mono should include /usr/local/sbin, /usr/local/b...

### DIFF
--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -86,7 +86,7 @@ module NETBuildpack::Runtime
       @config_vars["PKG_CONFIG_PATH"] = "$HOME/#{File.join(mono_lib,'pkgconfig')}:$PKG_CONFIG_PATH"
       @config_vars["C_INCLUDE_PATH"] = "$HOME/#{File.join(MONO_HOME,'include')}:$C_INCLUDE_PATH"
       @config_vars["ACLOCAL_PATH"] = "$HOME/#{File.join(MONO_HOME,'share','aclocal')}:$ACLOCAL_PATH"
-      @config_vars["PATH"] = "/usr/local/bin:/usr/bin:/bin:$HOME/#{mono_bin}:$PATH"
+      @config_vars["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$HOME/#{mono_bin}:$PATH"
       @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
       @config_vars["XDG_CONFIG_HOME"] = "$HOME/.config"
     end

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -20,7 +20,7 @@ require 'net_buildpack/runtime/mono'
 
 module NETBuildpack::Runtime
 
-  describe Mono do
+  describe Mono, :focus=>true do
 
     DETAILS = [NETBuildpack::Util::TokenizedVersion.new('3.2.0'), 'test-uri']
 
@@ -155,12 +155,29 @@ EXPECTED_START_SCRIPT
         expect(config_vars["C_INCLUDE_PATH"]).to include("$HOME/vendor/mono/include")
         expect(config_vars["ACLOCAL_PATH"]).to include("$HOME/vendor/mono/share/aclocal")
         expect(config_vars["PKG_CONFIG_PATH"]).to include("$HOME/vendor/mono/lib/pkgconfig")
-        expect(config_vars["PATH"]).to include("/usr/local/bin:/usr/bin:/bin:$HOME/vendor/mono/bin")
+        expect(config_vars["PATH"]).to include("$HOME/vendor/mono/bin")
         expect(config_vars["RUNTIME_COMMAND"]).to include("$HOME/vendor/mono/bin/mono")
         expect(config_vars["XDG_CONFIG_HOME"]).to include("$HOME/.config")
       end
     end
 
-  end
+    it 'should include /usr/local/sbin, /usr/local/bin, /usr/sbin, /usr/bin, /sbin, /bin in the path' do
+      Dir.mktmpdir do |root|
 
-end
+        config_vars = {}
+        Mono.new(
+            :app_dir => root,
+            :config_vars => config_vars
+        ).release
+
+        expect(config_vars["PATH"]).to include("/usr/local/sbin")
+        expect(config_vars["PATH"]).to include("/usr/local/bin")
+        expect(config_vars["PATH"]).to include("/usr/sbin")
+        expect(config_vars["PATH"]).to include("/usr/bin")
+        expect(config_vars["PATH"]).to include("/sbin")
+        expect(config_vars["PATH"]).to include("/bin")
+      end
+    end
+    
+  end # describe
+end #module

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -20,7 +20,7 @@ require 'net_buildpack/runtime/mono'
 
 module NETBuildpack::Runtime
 
-  describe Mono, :focus=>true do
+  describe Mono do
 
     DETAILS = [NETBuildpack::Util::TokenizedVersion.new('3.2.0'), 'test-uri']
 
@@ -178,6 +178,6 @@ EXPECTED_START_SCRIPT
         expect(config_vars["PATH"]).to include("/bin")
       end
     end
-    
+
   end # describe
 end #module


### PR DESCRIPTION
...in, /usr/sbin, /usr/bin, /sbin, /bin in the path - resolves #29
