### PR TITLE
Console container should raise an exception if more than one .exe.config is found

### DIFF
--- a/lib/net_buildpack/container/console.rb
+++ b/lib/net_buildpack/container/console.rb
@@ -51,17 +51,15 @@ module NETBuildpack::Container
         raise(ConsoleFoundTooManyExeError, "There are more than 1 potential .exe's that could be run by the Console container - #{exe_configs.inspect}"\
           +"\nYou should only have one .exe.config in #{@app_dir}") 
       end
+
+      puts "-----> Detected console app to be run using '#{start_run_script}'"
     end
 
     # Creates the command to run the Console application.
     #
     # @return [String] the command to run the application.
     def release
-      runtime_command = ContainerUtils.space(@runtime_command)
-      exe_string = ContainerUtils.space(console_executable)
-      arguments_string = ContainerUtils.space(arguments)
-
-      @start_script[:run] = "#{runtime_command}#{exe_string}#{arguments_string}".strip
+      @start_script[:run] = start_run_script
     end
 
     private
@@ -87,6 +85,14 @@ module NETBuildpack::Container
         exe_config = exe_config.gsub /#{@app_dir}\//, '' # make it relative
         exe = exe_config.gsub /.config/i, '' # reference the associated exe
         exe
+      end
+
+      def start_run_script
+        runtime_command = ContainerUtils.space(@runtime_command)
+        exe_string = ContainerUtils.space(console_executable)
+        arguments_string = ContainerUtils.space(arguments)
+
+        "#{runtime_command}#{exe_string}#{arguments_string}".strip
       end
 
   end

--- a/spec/net_buildpack/container/console_spec.rb
+++ b/spec/net_buildpack/container/console_spec.rb
@@ -48,6 +48,36 @@ module NETBuildpack::Container
       end
     end
 
+    it '[on compile] should raise an exception zero .exe.configs are found' do
+      Dir.mktmpdir do |root|
+
+        expect {
+          Console.new(
+              app_dir: root
+          ).compile
+        }.to raise_error ConsoleExeNotFoundError
+        
+      end
+    end
+
+    it '[on compile] should raise an exception if more than one .exe.config is found' do
+      Dir.mktmpdir do |root|
+        create_exe_config File.join(root, 'one.exe.config')
+        create_exe_config File.join(root, 'two.exe.config')
+
+        expect {
+          Console.new(
+              app_dir: root
+          ).compile
+        }.to raise_error ConsoleFoundTooManyExeError
+        
+      end
+    end
+
+    def create_exe_config(filename)
+      File.open(filename, 'w') { |f| f.write("<!-- stub .exe.config file -->")}
+    end
+
   end
 
 end


### PR DESCRIPTION
As per: #30

---

Currently, the Console container runs `.exe` associated with the ["first" `.exe.config` it finds]("Console" container - https://github.com/cloudfoundry-community/.net-buildpack/blob/master/lib/net_buildpack/container/console.rb#L67-L77) which is really confusing if you accidentally upload 2 exes.

Better behaviour would be:
1.  Throw an exception during bin/compile if more than one exe.config found.
2.  Print out which exe is being used by the Console container to start your app

---
1.  Looks like:

```
$ cf push my_console_app ...
...snip...
-----> Downloading Mono runtime 3.2.5_full from http://ci-labs-buildpack-downloads.s3.amazonaws.com/mono/lucid/x86_64/mono-3.2.5_full.tar.gz (3.9s)
       expanding Mono to vendor/mono (2.3s)
-----> Installing Mozilla certificate data to .config/.mono/certs (1.7s)
Compile failed with exception #<NETBuildpack::Container::ConsoleFoundTooManyExeError: There are more than 1 potential .exe's that could be run by the Console container - ["/tmp/staged/app/bin/SampleCommandlineApp2.exe.Config", "/tmp/staged/app/bin/SampleCommandlineApp.exe.Config"]
You should only have one .exe.config 
...snip...
```
1.  Looks like:

```
$ cf push my_console_app ...
...snip...
-----> Downloaded app package (4.0K)
Initialized empty Git repository in /tmp/buildpacks/.net-buildpack/.git/
-----> Downloading Mono runtime 3.2.5_full from http://ci-labs-buildpack-downloads.s3.amazonaws.com/mono/lucid/x86_64/mono-3.2.5_full.tar.gz (3.1s)
       expanding Mono to vendor/mono (2.2s)
-----> Installing Mozilla certificate data to .config/.mono/certs (1.6s)
-----> Detected console app to be run using '$HOME/vendor/mono/bin/mono --server SampleCommandlineApp.exe'
-----> Preparing AppSettingsAutoReconfiguration.exe 
-----> Uploading droplet (61M)
...snip...
```
