### PR TITLE
Limit max heap to ENV['MEMORY_LIMIT'] - 48M

### DIFF
--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -89,6 +89,7 @@ module NETBuildpack::Runtime
       @config_vars["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$HOME/#{mono_bin}:$PATH"
       @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
       @config_vars["XDG_CONFIG_HOME"] = "$HOME/.config"
+      @config_vars["MONO_GC_PARAMS"] = "major=marksweep-par,max-heap-size=86m"
     end
 
     def create_start_script

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -89,7 +89,7 @@ module NETBuildpack::Runtime
       @config_vars["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$HOME/#{mono_bin}:$PATH"
       @config_vars["RUNTIME_COMMAND"] = "#{runtime_command}"
       @config_vars["XDG_CONFIG_HOME"] = "$HOME/.config"
-      @config_vars["MONO_GC_PARAMS"] = "major=marksweep-par,max-heap-size=86m"
+      @config_vars["MONO_GC_PARAMS"] = "major=marksweep-par,max-heap-size=36m"
     end
 
     def create_start_script

--- a/lib/net_buildpack/runtime/mono.rb
+++ b/lib/net_buildpack/runtime/mono.rb
@@ -94,12 +94,12 @@ module NETBuildpack::Runtime
     end
 
     # Returns the max heap memory that can be used, based on ENV['MEMORY_LIMIT']
-    # This is basically the max available memory - 32MB
+    # This is basically the max available memory - 48MB
     #
     # @return [MemorySize, nil] the application's max heap memory limit or 512MB if no memory limit has been provided
     def max_heap
       memory_limit = ENV['MEMORY_LIMIT'] || "512M"
-      memory_limit_size = NETBuildpack::Util::MemorySize.new(memory_limit) - NETBuildpack::Util::MemorySize.new("32M")
+      memory_limit_size = NETBuildpack::Util::MemorySize.new(memory_limit) - NETBuildpack::Util::MemorySize.new("48M")
       fail "Invalid negative $MEMORY_LIMIT #{memory_limit}" if memory_limit_size < 0
       memory_limit_size
     end

--- a/lib/net_buildpack/util/memory_size.rb
+++ b/lib/net_buildpack/util/memory_size.rb
@@ -1,0 +1,161 @@
+# Encoding: utf-8
+# Cloud Foundry NET Buildpack
+# Copyright 2013 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'net_buildpack/runtime'
+
+module NETBuildpack::Util
+
+  # A class representing the size of a category of memory.
+  class MemorySize
+    include Comparable
+
+    # Creates a memory size based on a memory size string including a unit of 'K', 'M', or 'G'.
+    #
+    # @param [String] size a memory size including a unit
+    def initialize(size)
+      if size == '0'
+        @bytes = 0
+      else
+        fail "Invalid memory size '#{size}'" if !size || size.length < 2
+        unit = size[-1]
+        v = size[0..-2]
+        fail "Invalid memory size '#{size}'" unless MemorySize.is_integer v
+        v = size.to_i
+
+        # Store the number of bytes.
+        case unit
+        when 'b', 'B'
+          @bytes = v
+        when 'k', 'K'
+          @bytes = v * KILO
+        when 'm', 'M'
+          @bytes = KILO * KILO * v
+        when 'g', 'G'
+          @bytes = KILO * KILO * KILO * v
+        else
+          fail "Invalid unit '#{unit}' in memory size '#{size}'"
+        end
+      end
+    end
+
+    # Returns a memory size as a string including a unit. If the memory size is not a whole number, it is rounded down.
+    # The returned unit is always kilobytes, megabytes, or gigabytes which are commonly used units.
+    #
+    # @return [String] the memory size as a string, e.g. "10K"
+    def to_s
+      kilobytes = (@bytes / KILO).round
+      if kilobytes == 0
+        '0'
+      elsif kilobytes % KILO == 0
+        megabytes = kilobytes / KILO
+        if megabytes % KILO == 0
+          gigabytes = megabytes / KILO
+          gigabytes.to_s + 'G'
+        else
+          megabytes.to_s + 'M'
+        end
+      else
+        kilobytes.to_s + 'K'
+      end
+    end
+
+    # Compare this memory size with another memory size
+    #
+    # @param [MemorySize, 0] other
+    # @return [Numeric] the result
+    def <=>(other)
+      if other == 0
+        @bytes <=> 0
+      else
+        fail "Cannot compare a MemorySize to an instance of #{other.class}" unless other.is_a? MemorySize
+        @bytes <=> other.bytes
+      end
+    end
+
+    # Add a memory size to this memory size.
+    #
+    # @param [MemorySize] other the memory size to add
+    # @return [MemorySize] the result
+    def +(other)
+      memory_size_operation(other) do |self_bytes, other_bytes|
+        self_bytes + other_bytes
+      end
+    end
+
+    # Multiply this memory size by a numeric factor.
+    #
+    # @param [Numeric] other the factor to multiply by
+    # @return [MemorySize] the result
+    def *(other)
+      fail "Cannot multiply a Memory size by an instance of #{other.class}" unless other.is_a? Numeric
+      MemorySize.from_numeric((@bytes * other).round)
+    end
+
+    # Subtract a memory size from this memory size.
+    #
+    # @param [MemorySize] other the memory size to subtract
+    # @return [MemorySize] the result
+    def -(other)
+      memory_size_operation(other) do |self_bytes, other_bytes|
+        self_bytes - other_bytes
+      end
+    end
+
+    # Divide a memory size by a memory size or a numeric value. The units are respected, so the result of diving by a
+    # memory size is a numeric whereas the result of dividing by a numeric value is a memory size.
+    #
+    # @param [MemorySize, Numeric] other the memory size or numeric value to divide by
+    # @return [MemorySize, Numeric] the result
+    def /(other)
+      return @bytes / other.bytes.to_f if other.is_a? MemorySize
+      return MemorySize.from_numeric((@bytes / other.to_f).round) if other.is_a? Numeric
+      fail "Cannot divide a MemorySize by an instance of #{other.class}"
+    end
+
+    protected
+
+    # @!attribute [r] bytes
+    #   @return [Numeric] the size in bytes of this memory size
+    attr_reader :bytes
+
+    private
+
+    KILO = 1024
+
+    def memory_size_operation(other)
+      fail "Invalid parameter: instance of #{other.class} is not a MemorySize" unless other.is_a? MemorySize
+      MemorySize.from_numeric(yield @bytes, other.bytes)
+    end
+
+    def self.is_integer(v)
+      f = Float(v)
+      f && f.floor == f
+    rescue
+      false
+    end
+
+    def self.from_numeric(n)
+      MemorySize.new("#{n.to_s}B")
+    end
+
+    public
+
+    # Zero byte memory size
+    ZERO = from_numeric 0
+
+  end
+
+end

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -179,5 +179,19 @@ EXPECTED_START_SCRIPT
       end
     end
 
+    it 'should set MONO_GC_PARAMS with a limited the max heap size' do
+      Dir.mktmpdir do |root|
+
+        config_vars = {}
+        Mono.new(
+            :app_dir => root,
+            :config_vars => config_vars
+        ).release
+
+        expect(config_vars["MONO_GC_PARAMS"]).to include("major=marksweep-par")
+        expect(config_vars["MONO_GC_PARAMS"]).to include("max-heap-size=480M")
+      end
+    end
+
   end # describe
 end #module

--- a/spec/net_buildpack/runtime/mono_spec.rb
+++ b/spec/net_buildpack/runtime/mono_spec.rb
@@ -189,7 +189,7 @@ EXPECTED_START_SCRIPT
         ).release
 
         expect(config_vars["MONO_GC_PARAMS"]).to include("major=marksweep-par")
-        expect(config_vars["MONO_GC_PARAMS"]).to include("max-heap-size=480M")
+        expect(config_vars["MONO_GC_PARAMS"]).to include("max-heap-size=464M")
       end
     end
 

--- a/spec/net_buildpack/util/memory_size_spec.rb
+++ b/spec/net_buildpack/util/memory_size_spec.rb
@@ -1,0 +1,138 @@
+# Encoding: utf-8
+# Cloud Foundry NET Buildpack
+# Copyright 2013 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'net_buildpack/util/memory_size'
+
+describe NETBuildpack::Util::MemorySize do
+
+  let(:half_meg) { described_class.new('512K') }
+
+  let(:one_meg) { described_class.new('1M') }
+
+  it 'should accept a memory size in bytes, kilobytes, megabytes, or gigabytes' do
+    expect(described_class.new('1024B')).to eq(described_class.new('1k'))
+    expect(described_class.new('1024b')).to eq(described_class.new('1k'))
+    expect(described_class.new('1M')).to eq(described_class.new('1024k'))
+    expect(described_class.new('1m')).to eq(described_class.new('1024k'))
+    expect(described_class.new('1G')).to eq(described_class.new('1048576k'))
+    expect(described_class.new('1g')).to eq(described_class.new('1048576k'))
+  end
+
+  it 'should fail if nil is passed to  the constructor' do
+    expect { described_class.new(nil) }.to raise_error /Invalid/
+  end
+
+  it 'should accept a zero memory size with no unit' do
+    expect(described_class.new('0')).to eq(described_class.new('0k'))
+  end
+
+  it 'should fail if a non-zero memory size does not have a unit' do
+    expect { described_class.new('1') }.to raise_error /Invalid/
+  end
+
+  it 'should fail if a memory size has an invalid unit' do
+    expect { described_class.new('1A') }.to raise_error /Invalid/
+  end
+
+  it 'should fail if a memory size is not an number' do
+    expect { described_class.new('xm') }.to raise_error /Invalid/
+  end
+
+  it 'should fail if a memory size is not an integer' do
+    expect { described_class.new('1.1m') }.to raise_error /Invalid/
+  end
+
+  it 'should fail if a memory size has embedded whitespace' do
+    expect { described_class.new('1 1m') }.to raise_error /Invalid/
+  end
+
+  it 'should accept a negative value' do
+    expect(described_class.new('-1M')).to eq(described_class.new('-1024k'))
+  end
+
+  it 'should compare values correctly' do
+    expect(one_meg).to be < described_class.new('1025K')
+    expect(described_class.new('1025K')).to be > one_meg
+  end
+
+  it 'should compare a described_class to 0' do
+    expect(one_meg).to be > 0
+  end
+
+  it 'should fail when a memory size is compared to a non-zero numeric' do
+    expect { described_class.new('1B') < 2 }.to raise_error /Cannot compare/
+  end
+
+  it 'should multiply values correctly' do
+    expect(one_meg * 2).to eq(described_class.new('2M'))
+  end
+
+  it 'should fail when a memory size is multiplied by a memory size' do
+    expect { one_meg * one_meg }.to raise_error /Cannot multiply/
+  end
+
+  it 'should subtract memory values correctly' do
+    expect(one_meg - half_meg).to eq(half_meg)
+  end
+
+  it 'should fail when a numeric is subtracted from a memory size' do
+    expect { one_meg - 1 }.to raise_error /Invalid parameter: instance of Fixnum is not a MemorySize/
+  end
+
+  it 'should add memory values correctly' do
+    expect(half_meg + half_meg).to eq(one_meg)
+  end
+
+  it 'should fail when a numeric is added to a memory size' do
+    expect { one_meg + 1 }.to raise_error /Invalid parameter: instance of Fixnum is not a MemorySize/
+  end
+
+  it 'should divide a memory size by a numeric correctly' do
+    expect(one_meg / 2).to eq(half_meg)
+  end
+
+  it 'should divide a memory size by a numeric using floating point' do
+    expect(described_class.new('3B') / 2).to eq(described_class.new('2B'))
+  end
+
+  it 'should divide a memory size by another memory size correctly' do
+    expect(one_meg / half_meg).to eq(2)
+  end
+
+  it 'should divide a memory size by another memory size using floating point' do
+    expect(half_meg / one_meg).to eq(0.5)
+  end
+
+  it 'should fail when a memory size is divided by an incorrect type' do
+    expect { described_class.new('1B') / '' }.to raise_error /Cannot divide/
+  end
+
+  it 'should provide a zero memory size' do
+    expect(described_class::ZERO).to eq(described_class.new('0B'))
+  end
+
+  it 'should correctly convert the memory size to a string' do
+    expect(described_class::ZERO.to_s).to eq('0')
+    expect(described_class.new('1K').to_s).to eq('1K')
+    expect(described_class.new('1k').to_s).to eq('1K')
+    expect(described_class.new('1M').to_s).to eq('1M')
+    expect(described_class.new('1m').to_s).to eq('1M')
+    expect(described_class.new('1G').to_s).to eq('1G')
+    expect(described_class.new('1g').to_s).to eq('1G')
+  end
+
+end


### PR DESCRIPTION
Yes, 48M is completely arbitrary.

This sets ENV['MONO_GC_PARAMS']=="major=marksweep-par,max-heap-size=ENV['MEMORY_LIMIT']-48M"`

See http://www.mono-project.com/Release_Notes_Mono_2.8#Configuration for details on `MONO_GC_PARAMS` options
